### PR TITLE
LocaleDateTimeContext two-digit-year parameter check

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -28,6 +28,6 @@ public class JunitTest {
 
     @Test
     public void testDateTimeContextLocale() {
-        Assert.assertNotNull(DateTimeContexts.locale(Locale.forLanguageTag("EN-AU"), 1950));
+        Assert.assertNotNull(DateTimeContexts.locale(Locale.forLanguageTag("EN-AU"), 50));
     }
 }

--- a/src/main/java/walkingkooka/datetime/LocaleDateTimeContext.java
+++ b/src/main/java/walkingkooka/datetime/LocaleDateTimeContext.java
@@ -35,6 +35,9 @@ final class LocaleDateTimeContext implements DateTimeContext {
     static LocaleDateTimeContext with(final Locale locale,
                                       final int twoDigitYear) {
         Objects.requireNonNull(locale, "locale");
+        if(twoDigitYear < 0 || twoDigitYear > 99) {
+            throw new IllegalArgumentException("Invalid two digit year " + twoDigitYear + " expected beteen 0 and 100");
+        }
 
         return new LocaleDateTimeContext(locale, twoDigitYear);
     }

--- a/src/test/java/walkingkooka/datetime/LocaleDateTimeContextTest.java
+++ b/src/test/java/walkingkooka/datetime/LocaleDateTimeContextTest.java
@@ -30,6 +30,16 @@ public final class LocaleDateTimeContextTest implements DateTimeContextTesting2<
         assertThrows(NullPointerException.class, () -> LocaleDateTimeContext.with(null, 50));
     }
 
+    @Test
+    public void testWithNullNegativeTwoDigitYearFails() {
+        assertThrows(IllegalArgumentException.class, () -> LocaleDateTimeContext.with(Locale.ENGLISH, -1));
+    }
+
+    @Test
+    public void testWithNullInvalidTwoDigitYearFails2() {
+        assertThrows(IllegalArgumentException.class, () -> LocaleDateTimeContext.with(Locale.ENGLISH, 100));
+    }
+
     // ampm.............................................................................................................
 
     @Test


### PR DESCRIPTION
- Previously accepted any value
- Closes #https://github.com/mP1/walkingkooka-datetime/issues/22
- LocaleDateTimeContext.two-digit-year should validate range