### PR TITLE
Date.from(Instant) inlined. GWT *FIX*

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -1,11 +1,16 @@
 package test;
 
 import com.google.gwt.junit.client.GWTTestCase;
+import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.datetime.DateTime;
 import walkingkooka.datetime.DateTimeContexts;
 import walkingkooka.j2cl.locale.LocaleAware;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 @LocaleAware
@@ -45,6 +50,18 @@ public class TestGwtTest extends GWTTestCase {
                         50,
                         () -> LocalDateTime.now()
                 ).monthNames()
+        );
+    }
+
+    @Test
+    public void testDateTimeLocalDateToDate() {
+        assertEquals(
+                new Date(
+                        Date.UTC(2000 - 1900, Calendar.DECEMBER, 31, 0, 0, 0)
+                ),
+                DateTime.localDateToDate(
+                        LocalDate.of(2000, 12, 31)
+                )
         );
     }
 }

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -19,9 +19,13 @@ package test;
 import com.google.j2cl.junit.apt.J2clTestInput;
 import org.junit.Assert;
 import org.junit.Test;
+import walkingkooka.datetime.DateTime;
 import walkingkooka.datetime.DateTimeContexts;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 @J2clTestInput(JunitTest.class)
@@ -35,6 +39,18 @@ public class JunitTest {
                     1902,
                     50,
                     LocalDateTime::now
+                )
+        );
+    }
+
+    @Test
+    public void testDateTimeLocalDateToDate() {
+        Assert.assertEquals(
+                new Date(
+                        Date.UTC(2000 - 1900, Calendar.DECEMBER, 31, 0, 0, 0)
+                ),
+                DateTime.localDateToDate(
+                        LocalDate.of(2000, 12, 31)
                 )
         );
     }

--- a/src/main/java/walkingkooka/datetime/DateTime.java
+++ b/src/main/java/walkingkooka/datetime/DateTime.java
@@ -20,6 +20,7 @@ package walkingkooka.datetime;
 import walkingkooka.reflect.PublicStaticHelper;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -39,7 +40,7 @@ public final class DateTime implements PublicStaticHelper {
     public static Date localDateToDate(final LocalDate localDate) {
         Objects.requireNonNull(localDate, "localDate");
 
-        return Date.from(
+        return dateFromInstant(
                 localDate.atStartOfDay()
                         .toInstant(ZoneOffset.UTC)
         );
@@ -51,7 +52,7 @@ public final class DateTime implements PublicStaticHelper {
     public static Date localDateTimeToDate(final LocalDateTime localDateTime) {
         Objects.requireNonNull(localDateTime, "localDateTime");
 
-        return Date.from(
+        return dateFromInstant(
                 localDateTime.toInstant(ZoneOffset.UTC)
         );
     }
@@ -63,9 +64,16 @@ public final class DateTime implements PublicStaticHelper {
     public static Date localTimeToDate(final LocalTime localTime) {
         Objects.requireNonNull(localTime, "localTime");
 
-        return Date.from(
+        return dateFromInstant(
                 localTime.atDate(LocalDate.EPOCH)
                         .toInstant(ZoneOffset.UTC)
+        );
+    }
+
+    // Date.from(Instant) is not available in the GWT JRE.
+    private static Date dateFromInstant(final Instant instant) {
+        return new Date(
+                instant.toEpochMilli()
         );
     }
 


### PR DESCRIPTION
- Necessary to inline because GWT JRE does not emulate java.util.Date.from(Instant)